### PR TITLE
Reduce gc alloc

### DIFF
--- a/KK_SexFaces/FBSExtensions.cs
+++ b/KK_SexFaces/FBSExtensions.cs
@@ -71,12 +71,13 @@ namespace SexFaces
                 }
                 var meshCtrl = fbs.GetSkinnedMeshRenderer();
                 var mesh = meshCtrl.sharedMesh;
-                int vertCount = mesh.vertexCount;
+                var vertices = mesh.vertices;
+                int vertCount = vertices.Length;
                 var deltaVertsOpen = new Vector3[vertCount];
                 var deltaVertsClosed = new Vector3[vertCount];
                 var deltaNorms = new Vector3[vertCount];
                 var deltaTans = new Vector3[vertCount];
-                float halfWidth = mesh.vertices.Max(_ => _.x);
+                float halfWidth = vertices.Max(_ => _.x);
                 int openPtn = fbs.PtnSet[(int)basePtn].Open;
                 int closedPtn = fbs.PtnSet[(int)basePtn].Close;
                 mesh.GetBlendShapeFrameVertices(openPtn, 0, deltaVertsOpen, deltaNorms, deltaTans);
@@ -85,7 +86,7 @@ namespace SexFaces
                 var deltaVertsLopsided = new Vector3[vertCount];
                 for (int i = 0; i < vertCount; i++)
                 {
-                    float relativeX = Mathf.InverseLerp(-halfWidth, halfWidth, mesh.vertices[i].x);
+                    float relativeX = Mathf.InverseLerp(-halfWidth, halfWidth, vertices[i].x);
                     float blend = Sigmoid(relativeX);
                     if (leanRight)
                     {


### PR DESCRIPTION
Nice to meet you.
I am an engineer who has recently been looking into ways to improve the load times on Koikatsu.
There was a bit of heavy code in SexFace. This is a PR that fixes that.
Please merge if you don't mind.
Thanks for the nice plugin.

The internal alloc of mesh.vertices in the following code from AddLopsided was slowing things down.
One call to mesh.vertices is not a significant load, but the number of calls seems to have been too many.
![image](https://github.com/Sauceke/SexFaces/assets/4230203/ef2fd018-1860-43d2-82eb-3758103559cd)

I added the following logs before and after the series of processes and measured the time. it took 0.5 to 0.7 seconds per character.
![スクリーンショット 2024-02-18 221401](https://github.com/Sauceke/SexFaces/assets/4230203/36a8a3df-67d7-4f41-b1bd-499fca3c1c6f)

```
GCBytes 53051392 Time 0.582132
GCBytes 42024960 Time 0.6396368
GCBytes -91897856 Time 0.7382355
GCBytes -88330240 Time 0.7776159
```
I think the GCBytes is negative because the garbage collector was activated.

I was able to get around this by first getting mesh.vertices and then using it around.
```
GCBytes 1568768 Time 0.0056536
GCBytes 1564672 Time 0.0046379
GCBytes 1564672 Time 0.0045126
GCBytes 1564672 Time 0.0041868
```

This modification reduces the loading time for a scene with about 20 characters in place from 50 to 45 seconds.